### PR TITLE
添加证书二进制内容参数

### DIFF
--- a/client.go
+++ b/client.go
@@ -74,6 +74,29 @@ func (c *Client) WithCert(certFile, keyFile, rootcaFile string) error {
 	return nil
 }
 
+func (c *Client) WithCertBytes(certFile, keyFile, rootcaFile []byte) error {
+	cert, err := tls.X509KeyPair(certFile, keyFile)
+	if err != nil {
+		return err
+	}
+	pool := x509.NewCertPool()
+	ok := pool.AppendCertsFromPEM(rootcaFile)
+	if !ok {
+		return errors.New("failed to parse root certificate")
+	}
+	conf := &tls.Config{
+		Certificates: []tls.Certificate{cert},
+		RootCAs:      pool,
+	}
+	trans := &http.Transport{
+		TLSClientConfig: conf,
+	}
+	c.tlsClient = &http.Client{
+		Transport: trans,
+	}
+	return nil
+}
+
 // 发送请求
 func (c *Client) Post(url string, params Params, tls bool) (Params, error) {
 	var httpc *http.Client


### PR DESCRIPTION
由于我的证书文件是编译成二进制文件（用go-bindata），这样做的目的是不想把证书部署到服务器上，所以需要这个方法。